### PR TITLE
Update DamageNumbers.kt

### DIFF
--- a/src/main/kotlin/com/dulkirfabric/features/filters/DamageNumbers.kt
+++ b/src/main/kotlin/com/dulkirfabric/features/filters/DamageNumbers.kt
@@ -10,7 +10,7 @@ import net.minecraft.text.Text
 object DamageNumbers {
 
     private val nonCritFormat = """^(\d{1,3}(,\d{3})*|\d+)$""".toRegex()
-    private val trimPattern = "[✧,]".toRegex()
+    private val trimPattern = "[✧,❤]".toRegex()
     private val critColorList = listOf(
         "§e", "§f", "§c", "§6"
     )


### PR DESCRIPTION
adds the heart to regex to prevent a crash. Something is spawning the armor stands with a heart symbol in the name, not sure what. Whatever it is, it instantly crashes the game.