### PR TITLE
feat: improve etherwarp highlight

### DIFF
--- a/src/main/kotlin/com/dulkirfabric/Registrations.kt
+++ b/src/main/kotlin/com/dulkirfabric/Registrations.kt
@@ -80,7 +80,7 @@ object Registrations {
         EVENT_BUS.subscribe(SpeedOverlay)
         EVENT_BUS.subscribe(ActionBarUtil)
         EVENT_BUS.subscribe(ActionBarHudReplacements)
-        EVENT_BUS.subscribe(AotvHighlight)
+        EVENT_BUS.subscribe(EtherwarpHighlight)
         EVENT_BUS.subscribe(MiniBossHighlight)
         EVENT_BUS.subscribe(ScoreBoardUtils)
         EVENT_BUS.subscribe(HudRenderUtil)

--- a/src/main/kotlin/com/dulkirfabric/config/DulkirConfig.kt
+++ b/src/main/kotlin/com/dulkirfabric/config/DulkirConfig.kt
@@ -179,11 +179,20 @@ class DulkirConfig {
         )
         general.addEntry(
             entryBuilder.startAlphaColorField(
-                Text.literal("Etherwarp Preview Color"),
+                Text.literal("Etherwarp Valid Preview Color"),
                 configOptions.etherwarpPreviewColor
             )
                 .setDefaultValue(0x99FFFFFF.toInt())
                 .setSaveConsumer { newValue -> configOptions.etherwarpPreviewColor = newValue }
+                .build()
+        )
+        general.addEntry(
+            entryBuilder.startAlphaColorField(
+                Text.literal("Etherwarp Invalid Preview Color"),
+                0x99FF0000.toInt()
+            )
+                .setDefaultValue(0x99FF0000.toInt())
+                .setSaveConsumer { newValue -> configOptions.etherwarpInvalidPreviewColor = newValue }
                 .build()
         )
         general.addEntry(
@@ -412,6 +421,7 @@ class DulkirConfig {
         var hideHeldItemTooltip: Boolean = false,
         var showEtherwarpPreview: Boolean = true,
         var etherwarpPreviewColor: Int = 0x99FFFFFF.toInt(),
+        var etherwarpInvalidPreviewColor: Int = 0x99FF0000.toInt(),
         var announceMinis: Boolean = false,
         var boxMinis: Boolean = false,
         var attunementDisplay: Boolean = false,

--- a/src/main/kotlin/com/dulkirfabric/util/Utils.kt
+++ b/src/main/kotlin/com/dulkirfabric/util/Utils.kt
@@ -1,5 +1,6 @@
 package com.dulkirfabric.util
 
+import com.dulkirfabric.DulkirModFabric.mc
 import com.dulkirfabric.events.PlaySoundEvent
 import com.dulkirfabric.events.SlayerBossEvents
 import com.dulkirfabric.events.WorldLoadEvent
@@ -11,6 +12,7 @@ import net.minecraft.entity.Entity
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NbtCompound
 import net.minecraft.nbt.NbtHelper
+import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Vec3d
 
 object Utils {
@@ -42,6 +44,8 @@ object Utils {
         val prevPos = Vec3d(this.lastX, this.lastY, this.lastZ)
         return lerp(prevPos, this.pos, tickDelta)
     }
+
+    fun BlockPos.getBlockAt() = mc.world!!.getBlockState(this)
 
     @EventHandler
     fun detectSlayerEvents(event: ChatEvents.AllowChat) {


### PR DESCRIPTION
makes etherwarp highlight show a different color when you cant etherwarp to said block, and also makes it work with aote with etherwarp applied or the etherwarp merger item