### PR TITLE
fix: respect config for blaze slayer attunement display

### DIFF
--- a/src/main/kotlin/com/dulkirfabric/features/slayer/Demonlord.kt
+++ b/src/main/kotlin/com/dulkirfabric/features/slayer/Demonlord.kt
@@ -31,6 +31,7 @@ object Demonlord {
 
     @EventHandler
     fun attunementHighlight(event: WorldRenderLastEvent) {
+        if (!DulkirConfig.configOptions.attunementDisplay) return
         if (TablistUtils.persistentInfo.area != "Crimson Isle") return
         val ents = mc.world?.entities ?: return
         ents.forEach { ent ->


### PR DESCRIPTION
title. it wasn't checking whether the config option was enabled