### PR TITLE
fix: make max visitor alert not alert when disabled

### DIFF
--- a/src/main/kotlin/com/dulkirfabric/features/VisitorAlert.kt
+++ b/src/main/kotlin/com/dulkirfabric/features/VisitorAlert.kt
@@ -24,7 +24,7 @@ object VisitorAlert {
 
     @EventHandler
     private fun onLong(event: LongUpdateEvent) {
-        if (TablistUtils.persistentInfo.area != "Garden") return
+        if (!DulkirConfig.configOptions.visitorAlert || TablistUtils.persistentInfo.area != "Garden") return
         if (TablistUtils.persistentInfo.nextVisitorTime == "Queue Full!") {
             if (DulkirConfig.configOptions.persistentVisitorAlert) {
                 HudRenderUtil.drawTitle(


### PR DESCRIPTION
When going to garden the visitor alert feature popped up the title even when it was disabled. I fixed it by just making it return if the feature is disabled.

🥹